### PR TITLE
ci(docker): Upgrade Go base image to 1.25.5 and Debian to trixie

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     runc \
     libdevmapper1.02.1 \
     libgpgme11 \
-    libassuan0 \
+    libassuan9 \
     libseccomp2 \
     libsystemd0 \
     libbtrfs0 \


### PR DESCRIPTION
- Update Go version from 1.25 to 1.25.5 for security patches and bug fixes
- Switch base image from bullseye to trixie for latest Debian stable release
- Ensure builder stage uses latest stable versions for improved compatibility