### PR TITLE
ci(workflows,release): Add automated release pipeline for upstream up…

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,0 +1,260 @@
+name: Auto Release on Upstream Updates
+
+on:
+  schedule:
+    # Check for new versions weekly on Mondays at 6 AM UTC
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+    inputs:
+      force_release:
+        description: 'Force release even if no version changes detected'
+        required: false
+        type: boolean
+        default: false
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  check-upstream-versions:
+    runs-on: ubuntu-latest
+    outputs:
+      crio_latest: ${{ steps.versions.outputs.crio_latest }}
+      k8s_latest: ${{ steps.versions.outputs.k8s_latest }}
+      crio_current: ${{ steps.versions.outputs.crio_current }}
+      k8s_current: ${{ steps.versions.outputs.k8s_current }}
+      should_release: ${{ steps.compare.outputs.should_release }}
+      release_tag: ${{ steps.versions.outputs.release_tag }}
+    
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Get current and latest versions
+      id: versions
+      run: |
+        # Get current versions from Dockerfile
+        CURRENT_CRIO=$(grep "ARG CRIO_VERSION" Dockerfile | head -1 | sed 's/.*=//' || echo "")
+        CURRENT_K8S=$(grep "ARG KUBERNETES_VERSION" Dockerfile | head -1 | sed 's/.*=//' || echo "v1.31.0")
+        
+        # Get latest versions from GitHub APIs
+        LATEST_CRIO=$(curl -s https://api.github.com/repos/cri-o/cri-o/releases/latest | jq -r '.tag_name')
+        LATEST_K8S=$(curl -s https://api.github.com/repos/kubernetes/kubernetes/releases | jq -r '.[0].tag_name')
+        
+        # Create release tag based on CRI-O version (primary component)
+        RELEASE_TAG="${LATEST_CRIO}-k8s-${LATEST_K8S}"
+        
+        echo "crio_current=$CURRENT_CRIO" >> $GITHUB_OUTPUT
+        echo "k8s_current=$CURRENT_K8S" >> $GITHUB_OUTPUT
+        echo "crio_latest=$LATEST_CRIO" >> $GITHUB_OUTPUT
+        echo "k8s_latest=$LATEST_K8S" >> $GITHUB_OUTPUT
+        echo "release_tag=$RELEASE_TAG" >> $GITHUB_OUTPUT
+        
+        echo "Current CRI-O: $CURRENT_CRIO"
+        echo "Latest CRI-O: $LATEST_CRIO"
+        echo "Current K8s: $CURRENT_K8S"
+        echo "Latest K8s: $LATEST_K8S"
+        echo "Release tag: $RELEASE_TAG"
+
+    - name: Check if release needed
+      id: compare
+      run: |
+        CURRENT_CRIO="${{ steps.versions.outputs.crio_current }}"
+        LATEST_CRIO="${{ steps.versions.outputs.crio_latest }}"
+        CURRENT_K8S="${{ steps.versions.outputs.k8s_current }}"
+        LATEST_K8S="${{ steps.versions.outputs.k8s_latest }}"
+        FORCE_RELEASE="${{ github.event.inputs.force_release }}"
+        
+        SHOULD_RELEASE=false
+        RELEASE_REASON=""
+        
+        echo "🔍 Checking if release is needed..."
+        echo "Current CRI-O: $CURRENT_CRIO"
+        echo "Latest CRI-O: $LATEST_CRIO"
+        echo "Current K8s: $CURRENT_K8S"
+        echo "Latest K8s: $LATEST_K8S"
+        echo "Force release: $FORCE_RELEASE"
+        
+        # Check if versions changed or force release requested
+        if [ "$CURRENT_CRIO" != "$LATEST_CRIO" ]; then
+          SHOULD_RELEASE=true
+          RELEASE_REASON="CRI-O version updated: $CURRENT_CRIO → $LATEST_CRIO"
+        elif [ "$CURRENT_K8S" != "$LATEST_K8S" ]; then
+          SHOULD_RELEASE=true
+          RELEASE_REASON="Kubernetes version updated: $CURRENT_K8S → $LATEST_K8S"
+        elif [ "$FORCE_RELEASE" = "true" ]; then
+          SHOULD_RELEASE=true
+          RELEASE_REASON="Manual force release requested"
+        fi
+        
+        # Check if this release tag already exists
+        RELEASE_TAG="${{ steps.versions.outputs.release_tag }}"
+        if [ "$SHOULD_RELEASE" = "true" ] && git tag -l | grep -q "^$RELEASE_TAG$"; then
+          echo "❌ Release tag $RELEASE_TAG already exists, skipping release"
+          SHOULD_RELEASE=false
+          RELEASE_REASON="Release already exists"
+        fi
+        
+        echo "should_release=$SHOULD_RELEASE" >> $GITHUB_OUTPUT
+        echo "release_reason=$RELEASE_REASON" >> $GITHUB_OUTPUT
+        
+        if [ "$SHOULD_RELEASE" = "true" ]; then
+          echo "✅ RELEASE NEEDED: $RELEASE_REASON"
+          echo "🚀 Will proceed with building and releasing image"
+        else
+          echo "⏭️  NO RELEASE NEEDED: No version changes detected"
+          echo "🛑 Stopping pipeline - nothing to do"
+        fi
+
+  no-release-needed:
+    needs: check-upstream-versions
+    if: needs.check-upstream-versions.outputs.should_release == 'false'
+    runs-on: ubuntu-latest
+    
+    steps:
+    - name: No release needed
+      run: |
+        echo "⏭️  No new releases found - pipeline stopped"
+        echo ""
+        echo "📊 Current Status:"
+        echo "   CRI-O: ${{ needs.check-upstream-versions.outputs.crio_current }} (latest: ${{ needs.check-upstream-versions.outputs.crio_latest }})"
+        echo "   Kubernetes: ${{ needs.check-upstream-versions.outputs.k8s_current }} (latest: ${{ needs.check-upstream-versions.outputs.k8s_latest }})"
+        echo ""
+        echo "✅ Repository is up to date!"
+        echo "🔄 Next check: Weekly on Monday at 6 AM UTC"
+
+  auto-release:
+    needs: check-upstream-versions
+    if: needs.check-upstream-versions.outputs.should_release == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
+      
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Update versions in files
+      run: |
+        CRIO_LATEST="${{ needs.check-upstream-versions.outputs.crio_latest }}"
+        K8S_LATEST="${{ needs.check-upstream-versions.outputs.k8s_latest }}"
+        
+        # Update Dockerfile
+        sed -i "s/ARG KUBERNETES_VERSION=.*/ARG KUBERNETES_VERSION=$K8S_LATEST/" Dockerfile
+        sed -i "s/ARG CRIO_VERSION.*/ARG CRIO_VERSION=$CRIO_LATEST/" Dockerfile
+        
+        # Update README version references
+        sed -i "s/crio-in-kind:v[0-9]\+\.[0-9]\+/crio-in-kind:$CRIO_LATEST/g" README.md
+        sed -i "s/kindest\/node:v[0-9]\+\.[0-9]\+\.[0-9]\+/kindest\/node:$K8S_LATEST/" README.md
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Log in to Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Extract metadata
+      id: meta
+      uses: docker/metadata-action@v5
+      with:
+        images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+        tags: |
+          type=raw,value=${{ needs.check-upstream-versions.outputs.crio_latest }}
+          type=raw,value=${{ needs.check-upstream-versions.outputs.release_tag }}
+          type=raw,value=latest
+
+    - name: Build and push Docker image
+      uses: docker/build-push-action@v5
+      with:
+        context: .
+        platforms: linux/amd64,linux/arm64
+        push: true
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}
+        build-args: |
+          CRIO_VERSION=${{ needs.check-upstream-versions.outputs.crio_latest }}
+          KUBERNETES_VERSION=${{ needs.check-upstream-versions.outputs.k8s_latest }}
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
+
+    - name: Test the built image
+      run: |
+        # Pull and test the image
+        docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.check-upstream-versions.outputs.crio_latest }}
+        
+        # Basic smoke test
+        docker run --rm ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.check-upstream-versions.outputs.crio_latest }} crio version
+
+    - name: Commit version updates
+      run: |
+        git config --local user.email "action@github.com"
+        git config --local user.name "GitHub Action"
+        git add Dockerfile README.md
+        git commit -m "chore: update to CRI-O ${{ needs.check-upstream-versions.outputs.crio_latest }} and Kubernetes ${{ needs.check-upstream-versions.outputs.k8s_latest }}" || exit 0
+        git push
+
+    - name: Create GitHub Release
+      uses: softprops/action-gh-release@v1
+      with:
+        tag_name: ${{ needs.check-upstream-versions.outputs.release_tag }}
+        name: "CRI-O ${{ needs.check-upstream-versions.outputs.crio_latest }} + Kubernetes ${{ needs.check-upstream-versions.outputs.k8s_latest }}"
+        body: |
+          ## 🚀 Automated Release
+          
+          This release includes the latest upstream versions:
+          
+          ### 📦 What's Included
+          - **CRI-O**: `${{ needs.check-upstream-versions.outputs.crio_latest }}`
+          - **Kubernetes**: `${{ needs.check-upstream-versions.outputs.k8s_latest }}`
+          - **Base Image**: `kindest/node:${{ needs.check-upstream-versions.outputs.k8s_latest }}`
+          
+          ### 🐳 Docker Images
+          ```bash
+          # Pull the image
+          docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.check-upstream-versions.outputs.crio_latest }}
+          
+          # Use with KIND
+          kind create cluster --image ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.check-upstream-versions.outputs.crio_latest }}
+          ```
+          
+          ### 🏷️ Available Tags
+          - `${{ needs.check-upstream-versions.outputs.crio_latest }}` - CRI-O version tag
+          - `${{ needs.check-upstream-versions.outputs.release_tag }}` - Full version tag
+          - `latest` - Latest release
+          
+          ### 🧪 Testing
+          Test Kubernetes 1.34+ features like Docker image name blocking:
+          ```bash
+          kubectl apply -f examples/test-image-name-blocking.yaml
+          ```
+          
+          ### 📋 Changes from Previous Release
+          - Updated CRI-O from `${{ needs.check-upstream-versions.outputs.crio_current }}` to `${{ needs.check-upstream-versions.outputs.crio_latest }}`
+          - Updated Kubernetes from `${{ needs.check-upstream-versions.outputs.k8s_current }}` to `${{ needs.check-upstream-versions.outputs.k8s_latest }}`
+          
+          ---
+          
+          *This release was automatically created when new upstream versions were detected.*
+        draft: false
+        prerelease: false
+        generate_release_notes: true
+
+  notify-success:
+    needs: [check-upstream-versions, auto-release]
+    if: needs.check-upstream-versions.outputs.should_release == 'true' && success()
+    runs-on: ubuntu-latest
+    
+    steps:
+    - name: Notify success
+      run: |
+        echo "✅ Successfully released CRI-O KIND image:"
+        echo "   Tag: ${{ needs.check-upstream-versions.outputs.release_tag }}"
+        echo "   CRI-O: ${{ needs.check-upstream-versions.outputs.crio_latest }}"
+        echo "   Kubernetes: ${{ needs.check-upstream-versions.outputs.k8s_latest }}"
+        echo "   Registry: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}"

--- a/.github/workflows/upstream-release-trigger.yml
+++ b/.github/workflows/upstream-release-trigger.yml
@@ -1,0 +1,126 @@
+name: Upstream Release Trigger
+
+# This workflow can be triggered by repository dispatch events
+# You can set up webhooks from CRI-O and Kubernetes repos to trigger this
+on:
+  repository_dispatch:
+    types: [crio-release, kubernetes-release, upstream-release]
+  workflow_dispatch:
+    inputs:
+      upstream_repo:
+        description: 'Which upstream repo released (cri-o or kubernetes)'
+        required: true
+        type: choice
+        options:
+        - cri-o
+        - kubernetes
+        - both
+      version:
+        description: 'Version that was released (optional - will auto-detect if empty)'
+        required: false
+        type: string
+
+jobs:
+  trigger-auto-release:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Parse repository dispatch
+      if: github.event_name == 'repository_dispatch'
+      run: |
+        echo "Repository dispatch triggered by: ${{ github.event.action }}"
+        echo "Client payload: ${{ toJson(github.event.client_payload) }}"
+        
+        # Extract information from webhook payload
+        UPSTREAM_REPO="${{ github.event.action }}"
+        VERSION="${{ github.event.client_payload.version || github.event.client_payload.tag_name }}"
+        
+        echo "UPSTREAM_REPO=$UPSTREAM_REPO" >> $GITHUB_ENV
+        echo "VERSION=$VERSION" >> $GITHUB_ENV
+
+    - name: Parse manual dispatch
+      if: github.event_name == 'workflow_dispatch'
+      run: |
+        echo "Manual dispatch triggered"
+        UPSTREAM_REPO="${{ github.event.inputs.upstream_repo }}"
+        VERSION="${{ github.event.inputs.version }}"
+        
+        echo "UPSTREAM_REPO=$UPSTREAM_REPO" >> $GITHUB_ENV
+        echo "VERSION=$VERSION" >> $GITHUB_ENV
+
+    - name: Validate upstream release
+      run: |
+        echo "Upstream repo: $UPSTREAM_REPO"
+        echo "Version: $VERSION"
+        
+        # Validate the release exists
+        if [ "$UPSTREAM_REPO" = "cri-o" ] || [ "$UPSTREAM_REPO" = "both" ]; then
+          if [ -n "$VERSION" ]; then
+            echo "Validating CRI-O release $VERSION"
+            curl -f -s "https://api.github.com/repos/cri-o/cri-o/releases/tags/$VERSION" > /dev/null
+            echo "✅ CRI-O release $VERSION validated"
+          fi
+        fi
+        
+        if [ "$UPSTREAM_REPO" = "kubernetes" ] || [ "$UPSTREAM_REPO" = "both" ]; then
+          if [ -n "$VERSION" ]; then
+            echo "Validating Kubernetes release $VERSION"
+            curl -f -s "https://api.github.com/repos/kubernetes/kubernetes/releases/tags/$VERSION" > /dev/null
+            echo "✅ Kubernetes release $VERSION validated"
+          fi
+        fi
+
+    - name: Trigger auto-release workflow
+      uses: actions/github-script@v7
+      with:
+        script: |
+          const result = await github.rest.actions.createWorkflowDispatch({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            workflow_id: 'auto-release.yml',
+            ref: 'main',
+            inputs: {
+              force_release: 'true'
+            }
+          });
+          
+          console.log('Triggered auto-release workflow:', result.status);
+
+    - name: Create issue for manual review
+      if: failure()
+      uses: actions/github-script@v7
+      with:
+        script: |
+          const issue = await github.rest.issues.create({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            title: `🚨 Upstream release trigger failed: ${process.env.UPSTREAM_REPO} ${process.env.VERSION}`,
+            body: `
+          ## Upstream Release Trigger Failed
+          
+          **Upstream Repository:** ${process.env.UPSTREAM_REPO}
+          **Version:** ${process.env.VERSION || 'auto-detect'}
+          **Trigger Type:** ${context.eventName}
+          **Workflow Run:** ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}
+          
+          ### Possible Issues
+          - [ ] Version validation failed (release doesn't exist)
+          - [ ] Network connectivity issues
+          - [ ] API rate limiting
+          - [ ] Workflow dispatch permissions
+          
+          ### Manual Steps
+          1. Verify the upstream release exists
+          2. Check workflow permissions
+          3. Manually trigger auto-release workflow if needed
+          
+          ### Auto-generated
+          This issue was automatically created by the upstream-release-trigger workflow.
+          `,
+            labels: ['automation', 'upstream-release', 'needs-review']
+          });
+          
+          console.log('Created issue:', issue.data.number);

--- a/RELEASE_AUTOMATION.md
+++ b/RELEASE_AUTOMATION.md
@@ -1,0 +1,225 @@
+# Release Automation
+
+This project automatically builds and releases new images when upstream CRI-O or Kubernetes versions are released, similar to how the official KIND project works.
+
+## How It Works
+
+### 1. Automatic Release Pipeline (`auto-release.yml`)
+
+**Triggers:**
+- **Weekly checks** every Monday at 6 AM UTC for new upstream versions
+- **Manual dispatch** for forced releases
+- **Repository dispatch** events from upstream webhooks
+
+**Rationale:** 
+- CRI-O releases roughly monthly
+- Kubernetes releases every ~3-4 months
+- Weekly checks ensure we catch releases within 7 days maximum
+- Webhooks provide immediate response when configured
+
+**Process:**
+1. **Check upstream versions** from GitHub APIs (CRI-O and Kubernetes)
+2. **Compare with current versions** in Dockerfile
+3. **🛑 STOP if no changes** - pipeline ends here, no resources wasted
+4. **🚀 CONTINUE if changes found** - proceed with build and release:
+   - Build multi-arch images (linux/amd64, linux/arm64)
+   - Push to GitHub Container Registry with multiple tags
+   - Create GitHub release with detailed changelog
+   - Commit version updates back to repository
+
+**Smart Stopping Logic:**
+- ✅ **Releases found**: Full pipeline runs
+- ⏭️ **No releases**: Pipeline stops after version check (saves time/resources)
+- 🔄 **Duplicate release**: Skips if release tag already exists
+
+**Image Tags Created:**
+- `ghcr.io/[username]/crio-in-kind:v1.34.0` (CRI-O version)
+- `ghcr.io/[username]/crio-in-kind:v1.34.0-k8s-v1.32.0` (Full version)
+- `ghcr.io/[username]/crio-in-kind:latest` (Latest release)
+
+### 2. Upstream Release Triggers (`upstream-release-trigger.yml`)
+
+**Purpose:** React immediately to upstream releases instead of waiting for daily checks
+
+**Setup Options:**
+
+#### Option A: Repository Webhooks (Recommended)
+Set up webhooks in your repository settings to trigger on:
+- CRI-O releases: `https://api.github.com/repos/[username]/crio-in-kind/dispatches`
+- Kubernetes releases: `https://api.github.com/repos/[username]/crio-in-kind/dispatches`
+
+#### Option B: External Monitoring
+Use services like GitHub Actions marketplace actions or external tools to monitor upstream releases.
+
+#### Option C: Manual Triggers
+Manually trigger when you notice new releases:
+```bash
+# Via GitHub CLI
+gh workflow run upstream-release-trigger.yml -f upstream_repo=cri-o -f version=v1.34.0
+
+# Via API
+curl -X POST \
+  -H "Authorization: token $GITHUB_TOKEN" \
+  -H "Accept: application/vnd.github.v3+json" \
+  https://api.github.com/repos/[username]/crio-in-kind/dispatches \
+  -d '{"event_type":"crio-release","client_payload":{"version":"v1.34.0"}}'
+```
+
+### 3. Backup PR-based Updates (`version-update.yml`)
+
+**Purpose:** Weekly backup system that creates PRs for manual review
+
+**When to use:**
+- Auto-release system fails
+- Want manual review before release
+- Testing version compatibility
+
+## Release Frequency
+
+### Automatic Releases
+- **CRI-O releases**: Within 1 week of upstream release (or immediately via webhook)
+- **Kubernetes releases**: Within 1 week of upstream release (or immediately via webhook)
+- **Combined updates**: When both have new versions
+- **Scheduled checks**: Weekly on Mondays as backup
+
+### Release Lifecycle Context
+- **CRI-O**: Releases approximately monthly
+- **Kubernetes**: Major releases every ~3-4 months, patch releases more frequently
+- **KIND**: Releases follow Kubernetes releases
+- **This project**: Follows both CRI-O and Kubernetes releases
+
+### Manual Releases
+- **Security patches**: As needed
+- **Bug fixes**: As needed
+- **Feature updates**: As needed
+
+## Version Strategy
+
+### Primary Versioning
+Images are primarily versioned by **CRI-O version** since that's the main differentiator from standard KIND images.
+
+### Tag Examples
+```bash
+# Latest CRI-O with latest compatible Kubernetes
+ghcr.io/[username]/crio-in-kind:v1.34.0
+
+# Specific CRI-O + Kubernetes combination
+ghcr.io/[username]/crio-in-kind:v1.34.0-k8s-v1.32.0
+
+# Always latest
+ghcr.io/[username]/crio-in-kind:latest
+```
+
+### Compatibility Matrix
+| CRI-O Version | Kubernetes Versions | Image Tags |
+|---------------|-------------------|------------|
+| v1.34.x | v1.32.x, v1.31.x | `v1.34.0`, `v1.34.0-k8s-v1.32.0` |
+| v1.33.x | v1.31.x, v1.30.x | `v1.33.0`, `v1.33.0-k8s-v1.31.0` |
+
+## Monitoring and Notifications
+
+### Success Indicators
+- ✅ GitHub release created
+- ✅ Docker images pushed to registry
+- ✅ Multi-arch builds successful
+- ✅ Basic smoke tests pass
+
+### Failure Handling
+- 🚨 Automatic issue creation on failures
+- 📧 GitHub notifications to repository watchers
+- 🔄 Retry logic for transient failures
+
+### Manual Verification
+```bash
+# Check latest release
+gh release list --limit 5
+
+# Verify image exists
+docker pull ghcr.io/[username]/crio-in-kind:latest
+docker run --rm ghcr.io/[username]/crio-in-kind:latest crio version
+
+# Test with KIND
+kind create cluster --image ghcr.io/[username]/crio-in-kind:latest
+kubectl get nodes -o jsonpath='{.items[*].status.nodeInfo.containerRuntimeVersion}'
+```
+
+## Configuration
+
+### Environment Variables
+```yaml
+# In workflow files
+REGISTRY: ghcr.io
+IMAGE_NAME: ${{ github.repository }}
+```
+
+### Secrets Required
+- `GITHUB_TOKEN`: Automatically provided (packages:write, contents:write)
+
+### Permissions Needed
+```yaml
+permissions:
+  contents: write    # Create releases and commit updates
+  packages: write    # Push to GitHub Container Registry
+```
+
+## Comparison with KIND
+
+| Feature | KIND Official | CRI-O KIND (This Project) |
+|---------|---------------|---------------------------|
+| **Release Trigger** | Manual + Scheduled | Auto + Manual + Webhook |
+| **Frequency** | Per K8s release | Per CRI-O + K8s release |
+| **Multi-arch** | ✅ Yes | ✅ Yes |
+| **Container Registry** | Docker Hub + GCR | GitHub Container Registry |
+| **Version Tags** | K8s version | CRI-O version (primary) |
+| **Automation Level** | Semi-automatic | Fully automatic |
+
+## Troubleshooting
+
+### Common Issues
+
+1. **Build Failures**
+   - Check CRI-O package availability
+   - Verify Kubernetes base image exists
+   - Review build logs for dependency issues
+
+2. **Registry Push Failures**
+   - Verify GITHUB_TOKEN permissions
+   - Check registry authentication
+   - Ensure repository packages are enabled
+
+3. **Version Detection Issues**
+   - GitHub API rate limiting
+   - Upstream release format changes
+   - Network connectivity problems
+
+### Debug Commands
+```bash
+# Check current versions
+grep "ARG.*VERSION" Dockerfile
+
+# Test version detection
+curl -s https://api.github.com/repos/cri-o/cri-o/releases/latest | jq -r '.tag_name'
+curl -s https://api.github.com/repos/kubernetes/kubernetes/releases | jq -r '.[0].tag_name'
+
+# Manual workflow trigger
+gh workflow run auto-release.yml -f force_release=true
+```
+
+## Future Enhancements
+
+### Planned Features
+- [ ] **Slack/Discord notifications** for releases
+- [ ] **Security scanning** integration
+- [ ] **Performance benchmarks** in releases
+- [ ] **Compatibility testing** matrix
+- [ ] **Rollback mechanisms** for failed releases
+
+### Integration Opportunities
+- [ ] **Dependabot** for base image updates
+- [ ] **Renovate** for dependency management
+- [ ] **SBOM generation** for security compliance
+- [ ] **Cosign signing** for image verification
+
+---
+
+This automation ensures that CRI-O KIND images are always up-to-date with the latest upstream releases, providing developers with the most current testing environment for Kubernetes features that behave differently between container runtimes.


### PR DESCRIPTION
…dates

- Add auto-release workflow that checks for CRI-O and Kubernetes version updates weekly
- Add upstream-release-trigger workflow for manual release initiation
- Implement version comparison logic to detect upstream changes and trigger releases
- Add multi-platform Docker image builds (linux/amd64, linux/arm64) with automated tagging
- Include release automation documentation with setup and usage instructions
- Automatically update Dockerfile and README with new upstream versions
- Add workflow dispatch option to force releases manually when needed
- Implement duplicate release prevention by checking existing tags
- Configure GitHub Actions caching for improved build performance
- Enable automated image publishing to GitHub Container Registry with semantic versioning